### PR TITLE
Use new NPM package name

### DIFF
--- a/eejs.js
+++ b/eejs.js
@@ -2,6 +2,6 @@ var eejs = require('ep_etherpad-lite/node/eejs/');
 
 exports.eejsBlock_mySettings = function (hook_name, args, cb)
 {
-  args.content = args.content + eejs.require('ep_user_font_size/templates/user_font_sizeSettings.ejs', {settings : false});
+  args.content = args.content + eejs.require('ep_user_fontsize_version_2/templates/user_font_sizeSettings.ejs', {settings : false});
   return cb();
 }

--- a/ep.json
+++ b/ep.json
@@ -1,12 +1,12 @@
 {
   "parts": [
     {
-      "name": "ep_user_font_size",
+      "name": "ep_user_fontsize_version_2",
       "client_hooks": {
-        "postAceInit": "ep_user_font_size/static/js/index:postAceInit"
+        "postAceInit": "ep_user_fontsize_version_2/static/js/index:postAceInit"
       },
       "hooks": {
-        "eejsBlock_mySettings":"ep_user_font_size/eejs"
+        "eejsBlock_mySettings":"ep_user_fontsize_version_2/eejs"
       }
     }
   ]


### PR DESCRIPTION
When publishing the package under a new name (ep_user_fontsize_version_2) for 0.0.2 version, the paths in the code weren’t updated and the package didn’t work. Worse, it made Etherpad crash.

Note to @JohnMcLear: Once this PR is reviewed and merged, I’ll publish it myself, don’t worry.